### PR TITLE
make "report:next +tag" work in filters and unify queries

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -15,7 +15,7 @@ class DefaultController extends AbstractController
      */
     public function indexAction()
     {
-        return $this->redirectToRoute('list_report', ['report' => $this->getParameter('default_report')]);
+        return $this->redirectToRoute('list', ['q' => 'report:' . $this->getParameter('default_report')]);
     }
 
     /**

--- a/src/AppBundle/TaskInformation.php
+++ b/src/AppBundle/TaskInformation.php
@@ -46,7 +46,7 @@ class TaskInformation
 
         foreach ($this->reports as $report) {
             $list[$report] = [
-                'url'   => $this->router->generate('list_report', ['report' => $report]),
+                'url'   => $this->router->generate('list', ['q' => 'report:' . $report]),
                 'count' => count($this->taskManager->filterByReport($reports[$report]))
             ];
         }
@@ -64,7 +64,7 @@ class TaskInformation
         $taskwarrior = $this->taskManager->getTaskwarrior();
         foreach ($taskwarrior->projects() as $project) {
             $projects[$project] = [
-                'url'   => $this->router->generate('list_project', ['project' => $project]),
+                'url'   => $this->router->generate('list', ['q' => 'project:' . $project]),
                 'count' => count($this->taskManager->filterPending('project:' . $project))
             ];
         }
@@ -82,7 +82,7 @@ class TaskInformation
         $taskwarrior = $this->taskManager->getTaskwarrior();
         foreach ($taskwarrior->tags() as $tag) {
             $tags[$tag] = [
-                'url'   => $this->router->generate('list_tag', ['tag' => $tag]),
+                'url'   => $this->router->generate('list', ['q' => '+' . $tag]),
                 'count' => count($this->taskManager->filterPending('+' . $tag))
             ];
         }


### PR DESCRIPTION
see https://github.com/DavidBadura/Taskwarrior/pull/30
- this would make all navigation items processed by the same controller
- no discrepancy between  clicking on a report and afterwards clicking on "search" with the pre filled filter
- downside: no longer pure taskwarrior filters, but enhanced by the "report:foo" element

let's discuss this in the next days, if you are interested in this
